### PR TITLE
msm: vidc: avoid OOB write while accessing memory

### DIFF
--- a/drivers/media/platform/msm/vidc/venus_hfi.c
+++ b/drivers/media/platform/msm/vidc/venus_hfi.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2012-2016, The Linux Foundation. All rights reserved.
+/* Copyright (c) 2012-2016, 2020, The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -3525,12 +3525,14 @@ skip_power_off:
 	return;
 }
 
-static void venus_hfi_process_msg_event_notify(
+static void print_sfr_message(
 	struct venus_hfi_device *device, void *packet)
 {
 	struct hfi_sfr_struct *vsfr = NULL;
 	struct hfi_msg_event_notify_packet *event_pkt;
 	struct vidc_hal_msg_pkt_hdr *msg_hdr;
+	u32 vsfr_size = 0;
+	void *p = NULL;
 
 	msg_hdr = (struct vidc_hal_msg_pkt_hdr *)packet;
 	event_pkt =
@@ -3551,13 +3553,11 @@ static void venus_hfi_process_msg_event_notify(
 		vsfr = (struct hfi_sfr_struct *)
 				device->sfr.align_virtual_addr;
 		if (vsfr) {
-			void *p = memchr(vsfr->rg_data, '\0',
-							vsfr->bufSize);
-			/* SFR isn't guaranteed to be NULL terminated
-			since SYS_ERROR indicates that Venus is in the
-			process of crashing.*/
+			vsfr_size = vsfr->bufSize - sizeof(u32);
+			p = memchr(vsfr->rg_data, '\0', vsfr_size);
+			/* SFR isn't guaranteed to be NULL terminated */
 			if (p == NULL)
-				vsfr->rg_data[vsfr->bufSize - 1] = '\0';
+				vsfr->rg_data[vsfr_size - 1] = '\0';
 			dprintk(VIDC_ERR, "SFR Message from FW : %s\n",
 				vsfr->rg_data);
 		}
@@ -3690,7 +3690,6 @@ static void venus_hfi_response_handler(struct venus_hfi_device *device)
 {
 	u8 *packet = NULL;
 	u32 rc = 0;
-	struct hfi_sfr_struct *vsfr = NULL;
 
 	/*
 	 * check for clock adjust request from firmware
@@ -3711,12 +3710,7 @@ static void venus_hfi_response_handler(struct venus_hfi_device *device)
 			VIDC_WRAPPER_INTR_CLEAR_A2HWD_BMSK)) {
 			dprintk(VIDC_ERR, "Received: Watchdog timeout %s\n",
 				__func__);
-			vsfr = (struct hfi_sfr_struct *)
-					device->sfr.align_virtual_addr;
-			if (vsfr)
-				dprintk(VIDC_ERR,
-					"SFR Message from FW : %s\n",
-						vsfr->rg_data);
+			print_sfr_message(device, (void *)packet);
 			venus_hfi_process_sys_watchdog_timeout(device);
 		}
 
@@ -3742,7 +3736,7 @@ static void venus_hfi_response_handler(struct venus_hfi_device *device)
 				(struct vidc_hal_msg_pkt_hdr *) packet,
 				&device->sess_head, &device->session_lock);
 			if (rc == HFI_MSG_EVENT_NOTIFY) {
-				venus_hfi_process_msg_event_notify(
+				print_sfr_message(
 					device, (void *)packet);
 			} else if (rc == HFI_MSG_SYS_RELEASE_RESOURCE) {
 				dprintk(VIDC_DBG,


### PR DESCRIPTION
Exclude 4 bytes which holds the size of the buffer while
calculating the actual buffer size to avoid OOB write.

CRs-Fixed: 2534791

Change-Id: Ic8a80e07a2cbadd6cce197dcf4f359bdaea373d6
Signed-off-by: Paras Nagda <pnagda@codeaurora.org>